### PR TITLE
Iteration3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,4 @@
 # README
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
 
-Things you may want to cover:
-
-* Ruby version
-
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+schema link: https://app.dbdesigner.net/designer/schema/509755

--- a/app/controllers/ski_maker_skis_controller.rb
+++ b/app/controllers/ski_maker_skis_controller.rb
@@ -2,12 +2,16 @@ class SkiMakerSkisController < ApplicationController
 
 
   def index
-    require "pry"; binding.pry
+    # require "pry"; binding.pry
     if params[:sort] == 'alpha'
       @ski_maker = SkiMaker.find(params[:id])
       @skis = @ski_maker.sort_alpha
-    elsif params[:search] == 'length'
-      
+
+    elsif params[:longest_offered_cm]
+      length = params[:longest_offered_cm]
+      @ski_maker = SkiMaker.find(params[:id])
+      @skis = @ski_maker.over_given_length(length)
+      # require "pry"; binding.pry
     else
       @ski_maker = SkiMaker.find(params[:id])
       @skis = @ski_maker.skis

--- a/app/controllers/ski_maker_skis_controller.rb
+++ b/app/controllers/ski_maker_skis_controller.rb
@@ -2,11 +2,12 @@ class SkiMakerSkisController < ApplicationController
 
 
   def index
-    # @ski_maker = SkiMaker.find(params[:id])
+    require "pry"; binding.pry
     if params[:sort] == 'alpha'
       @ski_maker = SkiMaker.find(params[:id])
       @skis = @ski_maker.sort_alpha
-      # require "pry"; binding.pry
+    elsif params[:search] == 'length'
+      
     else
       @ski_maker = SkiMaker.find(params[:id])
       @skis = @ski_maker.skis

--- a/app/controllers/ski_maker_skis_controller.rb
+++ b/app/controllers/ski_maker_skis_controller.rb
@@ -2,7 +2,7 @@ class SkiMakerSkisController < ApplicationController
 
 
   def index
-    # require "pry"; binding.pry
+
     if params[:sort] == 'alpha'
       @ski_maker = SkiMaker.find(params[:id])
       @skis = @ski_maker.sort_alpha

--- a/app/controllers/ski_makers_controller.rb
+++ b/app/controllers/ski_makers_controller.rb
@@ -39,6 +39,11 @@ class SkiMakersController < ApplicationController
     redirect_to "/ski_makers/#{updated_maker.id}"
   end
 
+  def destroy
+    SkiMaker.destroy(params[:id])
+    redirect_to '/ski_makers'
+  end
+
 
 
 

--- a/app/controllers/ski_makers_controller.rb
+++ b/app/controllers/ski_makers_controller.rb
@@ -7,8 +7,6 @@ class SkiMakersController < ApplicationController
 
   def show
     @ski_maker = SkiMaker.find(params[:id])
-    @count = @ski_maker.skis.count
-
   end
 
   def new

--- a/app/controllers/skis_controller.rb
+++ b/app/controllers/skis_controller.rb
@@ -25,4 +25,9 @@ class SkisController < ApplicationController
     redirect_to "/skis/#{updated_ski.id}"
   end
 
+  def destroy
+    Ski.destroy(params[:id])
+      redirect_to "/skis"
+  end
+
 end

--- a/app/models/ski.rb
+++ b/app/models/ski.rb
@@ -16,6 +16,8 @@ class Ski < ApplicationRecord
   #   Ski.order(:model)
   # end
 
-
+  # def over_given_length
+  #   require "pry"; binding.pry
+  # end
 
 end

--- a/app/models/ski.rb
+++ b/app/models/ski.rb
@@ -7,17 +7,7 @@ class Ski < ApplicationRecord
   validates :symmetrical, inclusion: [true, false]
 
   def self.all_true
-    # require "pry"; binding.pry
     Ski.where(symmetrical: true)
-
   end
-
-  # def sort_alpha
-  #   Ski.order(:model)
-  # end
-
-  # def over_given_length
-  #   require "pry"; binding.pry
-  # end
 
 end

--- a/app/models/ski_maker.rb
+++ b/app/models/ski_maker.rb
@@ -3,7 +3,8 @@ class SkiMaker < ApplicationRecord
   validates_presence_of :years_active
   validates :makes_snowboards, inclusion: [true, false]
 
-  has_many :skis
+  has_many :skis,
+           dependent: :destroy
 
   def self.most_recent
     order('created_at DESC')

--- a/app/models/ski_maker.rb
+++ b/app/models/ski_maker.rb
@@ -21,4 +21,8 @@ class SkiMaker < ApplicationRecord
     over = skis.where("longest_offered_cm > ?", length)
   end
 
+  def skis_count
+    self.skis.count
+  end
+
 end

--- a/app/models/ski_maker.rb
+++ b/app/models/ski_maker.rb
@@ -14,13 +14,11 @@ class SkiMaker < ApplicationRecord
     skis = self.skis
     sorted = skis.order(:model)
     sorted
-    # require "pry"; binding.pry
   end
 
   def over_given_length(length)
     skis = self.skis
     over = skis.where("longest_offered_cm > ?", length)
-    # require "pry"; binding.pry
   end
 
 end

--- a/app/models/ski_maker.rb
+++ b/app/models/ski_maker.rb
@@ -17,6 +17,10 @@ class SkiMaker < ApplicationRecord
     # require "pry"; binding.pry
   end
 
-end
+  def over_given_length(length)
+    skis = self.skis
+    over = skis.where("longest_offered_cm > ?", length)
+    # require "pry"; binding.pry
+  end
 
-   # Ski.order(:model)
+end

--- a/app/views/ski_maker_skis/index.html.erb
+++ b/app/views/ski_maker_skis/index.html.erb
@@ -1,3 +1,4 @@
+
 <%= link_to 'See All Skis!', '/skis/' %> | <%= link_to 'See All Brands!', '/ski_makers/' %>
 <br>
 <br>
@@ -5,7 +6,7 @@
 <br>
 <br>
 
-<%= form_with(url: "/ski_makers/#{@ski_maker.id}/skis?search=length", method: "get") do %>
+<%= form_with(url: "/ski_makers/#{@ski_maker.id}/skis?search=length", method: "get", local: true) do %>
   <%= label_tag(:longest_offered_cm, "Show Skis Available Above This Length:") %>
   <%= text_field_tag(:longest_offered_cm) %>
   <%= submit_tag("Only Return Skis Over This Length") %>

--- a/app/views/ski_maker_skis/index.html.erb
+++ b/app/views/ski_maker_skis/index.html.erb
@@ -2,6 +2,14 @@
 <br>
 <br>
 <%= link_to 'Sort Alphabetically', "/ski_makers/#{@ski_maker.id}/skis?sort=alpha", method: :get %>
+<br>
+<br>
+
+<%= form_with(url: "/ski_makers/#{@ski_maker.id}/skis?search=length", method: "get") do %>
+  <%= label_tag(:length, "Show Skis Available Above This Length:") %>
+  <%= text_field_tag(:length) %>
+  <%= submit_tag("Only Return Skis Over This Length") %>
+<% end %>
 
 
 <h1><%= @ski_maker.company_name %></h1>

--- a/app/views/ski_maker_skis/index.html.erb
+++ b/app/views/ski_maker_skis/index.html.erb
@@ -15,8 +15,15 @@
 
 <h1><%= @ski_maker.company_name %></h1>
 <% @skis.each do |ski| %>
+<div id="ski-<%= ski.model  %>">
+
   <h3> Model Name:<%= " #{ski.model}"%></h3><strong>Ski Type: </strong><%=" #{ski.ski_type}"%><br><strong>Longest Offered Size: </strong><%=" #{ski.longest_offered_cm}"%><br><strong>100% Symmetrical? </strong><%=" #{ski.symmetrical}"%><br>
-  <a <br><%= link_to "Edit #{ski.model}", "/skis/#{ski.id}/edit" %></a> <br>
+  <a <br><%= link_to "Edit #{ski.model}", "/skis/#{ski.id}/edit" %></a> <br><br>
+  <a><%= link_to 'DELETE', "/skis/#{ski.id}", method: :delete %></a>
+
+</div>
+
+
 <% end %>
 <br><br>
 <%= link_to 'Create Skis', "/ski_makers/#{@ski_maker.id}/skis/new/"%>

--- a/app/views/ski_maker_skis/index.html.erb
+++ b/app/views/ski_maker_skis/index.html.erb
@@ -6,8 +6,8 @@
 <br>
 
 <%= form_with(url: "/ski_makers/#{@ski_maker.id}/skis?search=length", method: "get") do %>
-  <%= label_tag(:length, "Show Skis Available Above This Length:") %>
-  <%= text_field_tag(:length) %>
+  <%= label_tag(:longest_offered_cm, "Show Skis Available Above This Length:") %>
+  <%= text_field_tag(:longest_offered_cm) %>
   <%= submit_tag("Only Return Skis Over This Length") %>
 <% end %>
 

--- a/app/views/ski_makers/index.html.erb
+++ b/app/views/ski_makers/index.html.erb
@@ -2,5 +2,12 @@
 <%= link_to 'Add a Brand', '/ski_makers/new/' %>
 <h1>Ski Makers</h1>
 <% @ski_makers.each do |maker| %>
-  <%=maker.company_name%>  <strong>Added to Site: </strong><%= maker.created_at %> <%= link_to 'Edit', "/ski_makers/#{maker.id}/edit" %><br><br>
+  <div id="maker-<%= maker.company_name %>"> 
+    <%=maker.company_name%>
+    <strong>Added to Site: </strong>
+    <%= maker.created_at %>
+    <%= link_to 'Edit', "/ski_makers/#{maker.id}/edit" %>
+    <%= link_to 'DELETE', "/ski_makers/#{maker.id}", method: :delete %>
+    </div>
+    <br><br>
 <% end %>

--- a/app/views/ski_makers/show.html.erb
+++ b/app/views/ski_makers/show.html.erb
@@ -3,7 +3,7 @@
 <h1><%= @ski_maker.company_name %></h1>
 <p>Years Active: <%= @ski_maker.years_active %></p>
 <p>Makes Snowboards?: <%= @ski_maker.makes_snowboards %></p>
-<p>Skis Available: <%= @count %></p>
+<p>Skis Available: <%= @ski_maker.skis_count %></p>
 <%= link_to 'See These Skis!', "/ski_makers/#{@ski_maker.id}/skis" %>
 <br><br>
 <%= link_to 'Edit This Brand', "/ski_makers/#{@ski_maker.id}/edit" %>

--- a/app/views/ski_makers/show.html.erb
+++ b/app/views/ski_makers/show.html.erb
@@ -1,6 +1,5 @@
 <%= link_to 'See All Skis!', '/skis/' %>  <%= link_to 'See All Brands!', '/ski_makers/' %>
 
-
 <h1><%= @ski_maker.company_name %></h1>
 <p>Years Active: <%= @ski_maker.years_active %></p>
 <p>Makes Snowboards?: <%= @ski_maker.makes_snowboards %></p>
@@ -8,3 +7,5 @@
 <%= link_to 'See These Skis!', "/ski_makers/#{@ski_maker.id}/skis" %>
 <br><br>
 <%= link_to 'Edit This Brand', "/ski_makers/#{@ski_maker.id}/edit" %>
+<br><br>
+<%= link_to 'DELETE', "/ski_makers/#{@ski_maker.id}", method: :delete %>

--- a/app/views/skis/index.html.erb
+++ b/app/views/skis/index.html.erb
@@ -4,9 +4,15 @@
 <h1>All Skis</h1>
 
 <% @skis.each do |ski| %>
-<h3>Model Name: <%= ski.model %></h3>
-  <p><a>Ski Type: <%= ski.ski_type %></a><br>
-  <a>Longest Size Available: <%= ski.longest_offered_cm %></a><br>
-  <a>Symmetrical?: <%= ski.symmetrical %></a></p>
-  <a <%= link_to "Edit #{ski.model}", "/skis/#{ski.id}/edit" %></a>
+<div id="ski-<%= ski.model %>"
+
+  <h3>Model Name: <%= ski.model %></h3>
+    <p><a>Ski Type: <%= ski.ski_type %></a><br>
+      <a>Longest Size Available: <%= ski.longest_offered_cm %></a><br>
+      <a>Symmetrical?: <%= ski.symmetrical %></a></p>
+      <a> <%= link_to "Edit #{ski.model}", "/skis/#{ski.id}/edit" %></a><br><br>
+       <a><%= link_to 'DELETE', "/skis/#{ski.id}", method: :delete %></a>
+      <br>
+  </div>
+<br>
 <% end %>

--- a/app/views/skis/show.html.erb
+++ b/app/views/skis/show.html.erb
@@ -5,7 +5,10 @@
 Largest Available Size: <%= @ski.longest_offered_cm %><br>
 Symmetrical? <%= @ski.symmetrical %></p>
 
-<br>
-<br>
+<!-- <br> -->
+<!-- <br> -->
 
 <%= link_to 'Update Ski', "/skis/#{@ski.id}/edit" %>
+<br>
+<br>
+<%= link_to 'DELETE', "/skis/#{@ski.id}", method: :delete %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   get '/ski_makers/new', to: 'ski_makers#new'
   post '/ski_makers', to: 'ski_makers#create'
   get '/ski_makers/:id', to: 'ski_makers#show'
+  delete '/ski_makers/:id', to: 'ski_makers#destroy'
   get '/ski_makers/:id/edit', to: 'ski_makers#edit'
   patch '/ski_makers/:id', to: 'ski_makers#update'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,5 +18,7 @@ Rails.application.routes.draw do
   get '/skis', to: 'skis#index'
   get '/skis/:id', to: 'skis#show'
   get '/ski_makers/:id/skis', to: 'ski_maker_skis#index'
+  # delete '/ski_makers/:id/skis', to: 'skis#destroy'
+
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,6 @@ Rails.application.routes.draw do
   get '/skis', to: 'skis#index'
   get '/skis/:id', to: 'skis#show'
   get '/ski_makers/:id/skis', to: 'ski_maker_skis#index'
-  # delete '/ski_makers/:id/skis', to: 'skis#destroy'
 
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
 
   get '/skis/:id/edit', to: 'skis#edit'
   patch '/skis/:id', to: 'skis#update'
+  delete '/skis/:id', to: 'skis#destroy'
 
   get '/skis', to: 'skis#index'
   get '/skis/:id', to: 'skis#show'

--- a/spec/features/ski_makers/index_spec.rb
+++ b/spec/features/ski_makers/index_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe 'the /ski_makers index page' do
       fill_in 'Do They Make Snowboards?', with: false
 
       click_on 'Add Brand'
-      save_and_open_page
+
       expect(current_path).to eq("/ski_makers/")
       expect(page).to have_content("Armada")
       expect("Armada").to appear_before("#{icelantic.company_name}")

--- a/spec/features/ski_makers/index_spec.rb
+++ b/spec/features/ski_makers/index_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe 'the /ski_makers index page' do
     ski_maker4 = SkiMaker.create(company_name: "1000 Skis", years_active: 2, makes_snowboards: false)
 
     visit "/ski_makers/"
-    # save_and_open_page
     expect(page).to have_content(ski_maker1.company_name)
     expect(page).to have_content(ski_maker2.company_name)
     expect(page).to have_content(ski_maker3.company_name)
@@ -18,14 +17,20 @@ RSpec.describe 'the /ski_makers index page' do
 
   it 'displays ski_makers in order by created_at and shows created at on page' do
     faction = SkiMaker.create!(company_name: "Faction", years_active: 13, makes_snowboards: false)
-    agent = faction.skis.create!(model: "Agent", ski_type: "Park", longest_offered_cm: 195, symmetrical: true)
-    prodigy = faction.skis.create!(model: "Prodigy", ski_type: "Park", longest_offered_cm: 198, symmetrical: true)
-    ct = faction.skis.create!(model: "CT 2.0", ski_type: "Backcountry", longest_offered_cm: 213, symmetrical: false)
+    icelantic = SkiMaker.create!(company_name: "Icelantic", years_active: 15, makes_snowboards: false)
+    line = SkiMaker.create!(company_name: "Line", years_active: 15, makes_snowboards: false)
+    thousand = SkiMaker.create(company_name: "1000 Skis", years_active: 2, makes_snowboards: false)
+
+    # agent = faction.skis.create!(model: "Agent", ski_type: "Park", longest_offered_cm: 195, symmetrical: true)
+    # prodigy = faction.skis.create!(model: "Prodigy", ski_type: "Park", longest_offered_cm: 198, symmetrical: true)
+    # ct = faction.skis.create!(model: "CT 2.0", ski_type: "Backcountry", longest_offered_cm: 213, symmetrical: false)
 
     visit "/ski_makers/"
-    # save_and_open_page
+    save_and_open_page
 
     expect(page).to have_content("Added to Site: #{faction.created_at}")
+    expect("#{thousand.company_name}").to appear_before("#{line.company_name}")
+    expect("#{icelantic.company_name}").to appear_before("#{faction.company_name}")
   end
 
   it 'has clickable link to skis#index' do

--- a/spec/features/ski_makers/index_spec.rb
+++ b/spec/features/ski_makers/index_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe 'the /ski_makers index page' do
         click_on "DELETE"
 
       end
-      save_and_open_page
+      # save_and_open_page
       expect(current_path).to eq("/ski_makers")
       expect(page).to_not have_content("#{faction.company_name}")
       expect(page).to have_content("#{line.company_name}")

--- a/spec/features/ski_makers/index_spec.rb
+++ b/spec/features/ski_makers/index_spec.rb
@@ -99,5 +99,31 @@ RSpec.describe 'the /ski_makers index page' do
       expect(current_path).to eq("/ski_makers/#{line.id}/edit")
     end
 
+    it 'has a delete link to delete each ski maker' do
+      Ski.destroy_all
+      SkiMaker.destroy_all
+      faction = SkiMaker.create!(company_name: "Faction", years_active: 13, makes_snowboards: false)
+      line = SkiMaker.create!(company_name: "Line", years_active: 15, makes_snowboards: false)
+      _1000 = SkiMaker.create!(company_name: "1000 Skis", years_active: 2, makes_snowboards: false)
+      icelantic = SkiMaker.create!(company_name: "Icelantic", years_active: 15, makes_snowboards: false)
+
+      agent = faction.skis.create!(model: "Agent", ski_type: "Park", longest_offered_cm: 195, symmetrical: true)
+      blade = line.skis.create!(model: "BLADE", ski_type: "Powder", longest_offered_cm: 215, symmetrical: false)
+      park = _1000.skis.create!(model: "Park", ski_type: "Park/Pipe", longest_offered_cm: 199, symmetrical: true)
+      madien = icelantic.skis.create!(model: "Madien", ski_type: "Park", longest_offered_cm: 178, symmetrical: true)
+
+      visit "/ski_makers/"
+
+      within("#{_1000.company_name}") do
+        click_on "DELETE"
+      end
+
+      expect(current_path).to eq("/ski_makers")
+      expect(page).to_not have_content("#{_1000.company_name}")
+      expect(page).to have_content("#{line.company_name}")
+      expect(page).to have_content("#{faction.company_name}")  
+
+    end
+
 
 end

--- a/spec/features/ski_makers/index_spec.rb
+++ b/spec/features/ski_makers/index_spec.rb
@@ -21,12 +21,7 @@ RSpec.describe 'the /ski_makers index page' do
     line = SkiMaker.create!(company_name: "Line", years_active: 15, makes_snowboards: false)
     thousand = SkiMaker.create(company_name: "1000 Skis", years_active: 2, makes_snowboards: false)
 
-    # agent = faction.skis.create!(model: "Agent", ski_type: "Park", longest_offered_cm: 195, symmetrical: true)
-    # prodigy = faction.skis.create!(model: "Prodigy", ski_type: "Park", longest_offered_cm: 198, symmetrical: true)
-    # ct = faction.skis.create!(model: "CT 2.0", ski_type: "Backcountry", longest_offered_cm: 213, symmetrical: false)
-
     visit "/ski_makers/"
-    save_and_open_page
 
     expect(page).to have_content("Added to Site: #{faction.created_at}")
     expect("#{thousand.company_name}").to appear_before("#{line.company_name}")
@@ -90,9 +85,10 @@ RSpec.describe 'the /ski_makers index page' do
       fill_in 'Do They Make Snowboards?', with: false
 
       click_on 'Add Brand'
-
+      save_and_open_page
       expect(current_path).to eq("/ski_makers/")
       expect(page).to have_content("Armada")
+      expect("Armada").to appear_before("#{icelantic.company_name}")
 
     end
 

--- a/spec/features/ski_makers/index_spec.rb
+++ b/spec/features/ski_makers/index_spec.rb
@@ -114,14 +114,15 @@ RSpec.describe 'the /ski_makers index page' do
 
       visit "/ski_makers/"
 
-      within("#{_1000.company_name}") do
+      within "#maker-#{faction.company_name}" do
         click_on "DELETE"
-      end
 
+      end
+      save_and_open_page
       expect(current_path).to eq("/ski_makers")
-      expect(page).to_not have_content("#{_1000.company_name}")
+      expect(page).to_not have_content("#{faction.company_name}")
       expect(page).to have_content("#{line.company_name}")
-      expect(page).to have_content("#{faction.company_name}")  
+      expect(page).to have_content("#{_1000.company_name}")
 
     end
 

--- a/spec/features/ski_makers/new_spec.rb
+++ b/spec/features/ski_makers/new_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'New Ski Maker' do
       fill_in 'Do They Make Snowboards? (true or false)', with: false
 
       click_on 'Add Brand'
-      save_and_open_page
+      # save_and_open_page
       expect(current_path).to eq("/ski_makers/")
       expect(page).to have_content("Armada")
       expect("Armada").to appear_before("#{icelantic.company_name}")

--- a/spec/features/ski_makers/new_spec.rb
+++ b/spec/features/ski_makers/new_spec.rb
@@ -22,9 +22,10 @@ RSpec.describe 'New Ski Maker' do
       fill_in 'Do They Make Snowboards? (true or false)', with: false
 
       click_on 'Add Brand'
-
+      save_and_open_page
       expect(current_path).to eq("/ski_makers/")
       expect(page).to have_content("Armada")
+      expect("Armada").to appear_before("#{icelantic.company_name}")
 
     end
   end

--- a/spec/features/ski_makers/show_spec.rb
+++ b/spec/features/ski_makers/show_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'the /ski_makers/:id show page' do
     visit "/ski_makers/#{faction.id}"
     # save_and_open_page
 
-    expect(page).to have_content('Skis Available: 3')
+    expect(page).to have_content("Skis Available: #{faction.skis_count}")
   end
 
   it 'has clickable link to skis#index' do

--- a/spec/features/ski_makers/show_spec.rb
+++ b/spec/features/ski_makers/show_spec.rb
@@ -65,5 +65,30 @@ RSpec.describe 'the /ski_makers/:id show page' do
     expect(current_path).to eq("/ski_makers/#{icelantic.id}/skis")
   end
 
+  it 'has a clickable link to destroy the #show pages ski maker' do
+    Ski.destroy_all
+    SkiMaker.destroy_all
+
+    salomon = SkiMaker.create!(company_name: "Salomon", years_active: 35, makes_snowboards: true)
+    spark = salomon.skis.create!(model: "QST Spark", ski_type: "Park", longest_offered_cm: 189, symmetrical: true)
+    blank = salomon.skis.create!(model: "QST Blank", ski_type: "All Mountain", longest_offered_cm: 202, symmetrical: false)
+
+    faction = SkiMaker.create!(company_name: "Faction", years_active: 13, makes_snowboards: false)
+    agent = faction.skis.create!(model: "Agent", ski_type: "Park", longest_offered_cm: 195, symmetrical: true)
+    prodigy = faction.skis.create!(model: "Prodigy", ski_type: "Park", longest_offered_cm: 198, symmetrical: true)
+    ct = faction.skis.create!(model: "CT 2.0", ski_type: "Backcountry", longest_offered_cm: 213, symmetrical: false)
+
+    visit "/ski_makers/#{salomon.id}"
+    click_on 'Delete'
+
+    expect(current_path).to eq("/ski_makers")
+    expect(page).to_not have_content("#{salomon.company_name}")
+    expect(page).to_not have_content("#{salomon.created_at}")
+
+    expect(page).to have_content("#{faction.company_name}")
+    expect(page).to have_content("#{faction.created_at}")
+
+  end
+
 
 end

--- a/spec/features/ski_makers/show_spec.rb
+++ b/spec/features/ski_makers/show_spec.rb
@@ -82,8 +82,9 @@ RSpec.describe 'the /ski_makers/:id show page' do
     click_on 'DELETE'
 
     expect(current_path).to eq("/ski_makers")
+    save_and_open_page
     expect(page).to_not have_content("#{salomon.company_name}")
-    expect(page).to_not have_content("#{salomon.created_at}")
+    # expect(page).to_not have_content("#{salomon.created_at}")
 
     expect(page).to have_content("#{faction.company_name}")
     expect(page).to have_content("#{faction.created_at}")

--- a/spec/features/ski_makers/show_spec.rb
+++ b/spec/features/ski_makers/show_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'the /ski_makers/:id show page' do
     click_on 'DELETE'
 
     expect(current_path).to eq("/ski_makers")
-    save_and_open_page
+    # save_and_open_page
     expect(page).to_not have_content("#{salomon.company_name}")
     # expect(page).to_not have_content("#{salomon.created_at}")
 

--- a/spec/features/ski_makers/show_spec.rb
+++ b/spec/features/ski_makers/show_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe 'the /ski_makers/:id show page' do
     ct = faction.skis.create!(model: "CT 2.0", ski_type: "Backcountry", longest_offered_cm: 213, symmetrical: false)
 
     visit "/ski_makers/#{faction.id}"
-    # save_and_open_page
 
     expect(page).to have_content("Skis Available: #{faction.skis_count}")
   end
@@ -82,10 +81,8 @@ RSpec.describe 'the /ski_makers/:id show page' do
     click_on 'DELETE'
 
     expect(current_path).to eq("/ski_makers")
-    # save_and_open_page
-    expect(page).to_not have_content("#{salomon.company_name}")
-    # expect(page).to_not have_content("#{salomon.created_at}")
 
+    expect(page).to_not have_content("#{salomon.company_name}")
     expect(page).to have_content("#{faction.company_name}")
     expect(page).to have_content("#{faction.created_at}")
 

--- a/spec/features/ski_makers/show_spec.rb
+++ b/spec/features/ski_makers/show_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe 'the /ski_makers/:id show page' do
     ct = faction.skis.create!(model: "CT 2.0", ski_type: "Backcountry", longest_offered_cm: 213, symmetrical: false)
 
     visit "/ski_makers/#{salomon.id}"
-    click_on 'Delete'
+    click_on 'DELETE'
 
     expect(current_path).to eq("/ski_makers")
     expect(page).to_not have_content("#{salomon.company_name}")

--- a/spec/features/ski_makers/skis/index_spec.rb
+++ b/spec/features/ski_makers/skis/index_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe 'the /ski_makes/:id/skis' do
     click_on 'Only Return Skis Over This Length'
 
     expect(current_path).to eq("/ski_makers/#{icelantic.id}/skis")
-    save_and_open_page
+    # save_and_open_page
     expect(page).to_not have_content("Model Name: #{maiden.model}")
     expect(page).to_not have_content("Longest Offered Size: #{maiden.longest_offered_cm}")
 
@@ -130,6 +130,33 @@ RSpec.describe 'the /ski_makes/:id/skis' do
     expect(page).to have_content("Longest Offered Size: #{shaman.longest_offered_cm}")
     expect(page).to have_content("Model Name: #{saba.model}")
     expect(page).to have_content("Longest Offered Size: #{saba.longest_offered_cm}")
+  end
+
+
+  it 'has a link to delete ski next to each ski, clicking refreshes page with ski destroyed' do
+    Ski.destroy_all
+    SkiMaker.destroy_all
+
+    salomon = SkiMaker.create!(company_name: "Salomon", years_active: 35, makes_snowboards: true)
+
+    spark = salomon.skis.create!(model: "QST Spark", ski_type: "Park", longest_offered_cm: 189, symmetrical: true)
+    blank = salomon.skis.create!(model: "QST Blank", ski_type: "All Mountain", longest_offered_cm: 202, symmetrical: true)
+    dumont = salomon.skis.create!(model: "Dumont Pro", ski_type: "Park", longest_offered_cm: 177, symmetrical: true)
+
+    visit "/ski_makers/#{salomon.id}/skis"
+
+    within "#ski-#{blank.model}" do
+      click_on "DELETE"
+    end
+    save_and_open_page
+    expect(current_path).to eq("/ski_makers/#{salomon.id}/skis")
+    expect(page).to_not have_content("Model Name: #{blank.model}")
+    expect(page).to have_content("Model Name: #{spark.model}")
+    expect(page).to have_content("Model Name: #{dumont.model}")
+
+
+
+
   end
 # bundle exec rspec spec/features/ski_makers/skis/index_spec.rb:105
 

--- a/spec/features/ski_makers/skis/index_spec.rb
+++ b/spec/features/ski_makers/skis/index_spec.rb
@@ -141,22 +141,18 @@ RSpec.describe 'the /ski_makes/:id/skis' do
 
     spark = salomon.skis.create!(model: "QST Spark", ski_type: "Park", longest_offered_cm: 189, symmetrical: true)
     blank = salomon.skis.create!(model: "QST Blank", ski_type: "All Mountain", longest_offered_cm: 202, symmetrical: true)
-    dumont = salomon.skis.create!(model: "Dumont Pro", ski_type: "Park", longest_offered_cm: 177, symmetrical: true)
+    dumont = salomon.skis.create!(model: "Dumont", ski_type: "Park", longest_offered_cm: 177, symmetrical: true)
 
     visit "/ski_makers/#{salomon.id}/skis"
 
-    within "#ski-#{blank.model}" do
+    within "#ski-#{dumont.model}" do
       click_on "DELETE"
     end
     save_and_open_page
-    expect(current_path).to eq("/ski_makers/#{salomon.id}/skis")
-    expect(page).to_not have_content("Model Name: #{blank.model}")
+    expect(current_path).to eq("/skis")
+    expect(page).to_not have_content("Model Name: #{dumont.model}")
     expect(page).to have_content("Model Name: #{spark.model}")
-    expect(page).to have_content("Model Name: #{dumont.model}")
-
-
-
-
+    expect(page).to have_content("Model Name: #{blank.model}")
   end
 # bundle exec rspec spec/features/ski_makers/skis/index_spec.rb:105
 

--- a/spec/features/ski_makers/skis/index_spec.rb
+++ b/spec/features/ski_makers/skis/index_spec.rb
@@ -117,10 +117,10 @@ RSpec.describe 'the /ski_makes/:id/skis' do
 
     fill_in "Show Skis Available Above This Length:", with: 190
 
-    click_on 'Only return records with a longest offered cm over 190'
+    click_on 'Only Return Skis Over This Length'
 
     expect(current_path).to eq("/ski_makers/#{icelantic.id}/skis")
-
+    save_and_open_page
     expect(page).to_not have_content("Model Name: #{maden.model}")
     expect(page).to_not have_content("Longest Offered Size: #{maden.longest_offered_cm}")
 
@@ -131,6 +131,6 @@ RSpec.describe 'the /ski_makes/:id/skis' do
     expect(page).to have_content("Model Name: #{saba.model}")
     expect(page).to have_content("Longest Offered Size: #{saba.longest_offered_cm}")
   end
-# bundle exec rspec spec/features/ski_makers/skis/index_spec.rb:65
+# bundle exec rspec spec/features/ski_makers/skis/index_spec.rb:105
 
 end

--- a/spec/features/ski_makers/skis/index_spec.rb
+++ b/spec/features/ski_makers/skis/index_spec.rb
@@ -102,6 +102,35 @@ RSpec.describe 'the /ski_makes/:id/skis' do
     expect(current_path).to eq("/skis/#{nomad.id}/edit")
   end
 
+  it 'has a form to that allows user to see all skis over 190 cm' do
+    Ski.destroy_all
+    SkiMaker.destroy_all
+
+    icelantic = SkiMaker.create!(company_name: "Icelantic", years_active: 15, makes_snowboards: false)
+
+    nomad = icelantic.skis.create!(model: "Nomad", ski_type: "Park", longest_offered_cm: 191, symmetrical: true)
+    shaman = icelantic.skis.create!(model: "Shaman", ski_type: "Powder", longest_offered_cm: 209, symmetrical: false)
+    madien = icelantic.skis.create!(model: "Madien", ski_type: "Park", longest_offered_cm: 178, symmetrical: true)
+    saba = icelantic.skis.create!(model: "Saba", ski_type: "All Mountain", longest_offered_cm: 201, symmetrical: false)
+
+    visit "/ski_makers/#{icelantic.id}/skis"
+
+    fill_in "Show Skis Available Above This Length:", with: 190
+
+    click_on 'Only return records with a longest offered cm over 190'
+
+    expect(current_path).to eq("/ski_makers/#{icelantic.id}/skis")
+
+    expect(page).to_not have_content("Model Name: #{maden.model}")
+    expect(page).to_not have_content("Longest Offered Size: #{maden.longest_offered_cm}")
+
+    expect(page).to have_content("Model Name: #{nomad.model}")
+    expect(page).to have_content("Longest Offered Size: #{nomad.longest_offered_cm}")
+    expect(page).to have_content("Model Name: #{shaman.model}")
+    expect(page).to have_content("Longest Offered Size: #{shaman.longest_offered_cm}")
+    expect(page).to have_content("Model Name: #{saba.model}")
+    expect(page).to have_content("Longest Offered Size: #{saba.longest_offered_cm}")
+  end
 # bundle exec rspec spec/features/ski_makers/skis/index_spec.rb:65
 
 end

--- a/spec/features/ski_makers/skis/index_spec.rb
+++ b/spec/features/ski_makers/skis/index_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe 'the /ski_makes/:id/skis' do
     ski_5 = ski_maker2.skis.create(model: "All MTN", ski_type: "All Mountain", longest_offered_cm: 201, symmetrical: false)
 
     visit "/ski_makers/#{ski_maker1.id}/skis"
-    # save_and_open_page
 
     expect(page).to have_content(ski_1.model)
     expect(page).to have_content(ski_1.ski_type)
@@ -79,7 +78,6 @@ RSpec.describe 'the /ski_makes/:id/skis' do
     click_on 'Sort Alphabetically'
     expect(current_path).to eq("/ski_makers/#{icelantic.id}/skis")
 
-    # save_and_open_page
     expect("Model Name: #{madien.model}").to appear_before("Model Name: #{nomad.model}")
     expect("Model Name: #{saba.model}").to appear_before("Model Name: #{shaman.model}")
   end
@@ -148,7 +146,7 @@ RSpec.describe 'the /ski_makes/:id/skis' do
     within "#ski-#{dumont.model}" do
       click_on "DELETE"
     end
-    
+
     expect(current_path).to eq("/skis")
     expect(page).to_not have_content("Model Name: #{dumont.model}")
     expect(page).to have_content("Model Name: #{spark.model}")

--- a/spec/features/ski_makers/skis/index_spec.rb
+++ b/spec/features/ski_makers/skis/index_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe 'the /ski_makes/:id/skis' do
 
     nomad = icelantic.skis.create!(model: "Nomad", ski_type: "Park", longest_offered_cm: 191, symmetrical: true)
     shaman = icelantic.skis.create!(model: "Shaman", ski_type: "Powder", longest_offered_cm: 209, symmetrical: false)
-    madien = icelantic.skis.create!(model: "Madien", ski_type: "Park", longest_offered_cm: 178, symmetrical: true)
+    maiden = icelantic.skis.create!(model: "Madien", ski_type: "Park", longest_offered_cm: 178, symmetrical: true)
     saba = icelantic.skis.create!(model: "Saba", ski_type: "All Mountain", longest_offered_cm: 201, symmetrical: false)
 
     visit "/ski_makers/#{icelantic.id}/skis"
@@ -121,8 +121,8 @@ RSpec.describe 'the /ski_makes/:id/skis' do
 
     expect(current_path).to eq("/ski_makers/#{icelantic.id}/skis")
     save_and_open_page
-    expect(page).to_not have_content("Model Name: #{maden.model}")
-    expect(page).to_not have_content("Longest Offered Size: #{maden.longest_offered_cm}")
+    expect(page).to_not have_content("Model Name: #{maiden.model}")
+    expect(page).to_not have_content("Longest Offered Size: #{maiden.longest_offered_cm}")
 
     expect(page).to have_content("Model Name: #{nomad.model}")
     expect(page).to have_content("Longest Offered Size: #{nomad.longest_offered_cm}")

--- a/spec/features/ski_makers/skis/index_spec.rb
+++ b/spec/features/ski_makers/skis/index_spec.rb
@@ -148,12 +148,11 @@ RSpec.describe 'the /ski_makes/:id/skis' do
     within "#ski-#{dumont.model}" do
       click_on "DELETE"
     end
-    save_and_open_page
+    
     expect(current_path).to eq("/skis")
     expect(page).to_not have_content("Model Name: #{dumont.model}")
     expect(page).to have_content("Model Name: #{spark.model}")
     expect(page).to have_content("Model Name: #{blank.model}")
   end
-# bundle exec rspec spec/features/ski_makers/skis/index_spec.rb:105
 
 end

--- a/spec/features/ski_makers/update_spec.rb
+++ b/spec/features/ski_makers/update_spec.rb
@@ -46,24 +46,10 @@ RSpec.describe 'can update a ski_maker(parent)' do
 
       click_on "Update"
 
-      # save_and_open_page
-
       expect(current_path).to eq("/ski_makers/#{line.id}")
       expect(page).to have_content('Line Skis')
       expect(page).to have_content("Years Active: 22")
     end
-
-
-
-
-
-
-
-
-
   end
-
-
-
 
 end

--- a/spec/features/ski_makers/update_spec.rb
+++ b/spec/features/ski_makers/update_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe 'can update a ski_maker(parent)' do
 
       click_on "Update"
 
-      save_and_open_page
+      # save_and_open_page
 
       expect(current_path).to eq("/ski_makers/#{line.id}")
       expect(page).to have_content('Line Skis')

--- a/spec/features/skis/ski_show_spec.rb
+++ b/spec/features/skis/ski_show_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe 'the /skis/:id show page' do
     click_on 'DELETE'
 
     expect(current_path).to eq("/skis")
-    save_and_open_page
+    # save_and_open_page
 
     expect(page).to_not have_content("Model Name: #{blank.model}")
     expect(page).to_not have_content("Longest Size Available: #{blank.longest_offered_cm}")

--- a/spec/features/skis/ski_show_spec.rb
+++ b/spec/features/skis/ski_show_spec.rb
@@ -45,4 +45,25 @@ RSpec.describe 'the /skis/:id show page' do
     expect(current_path).to eq("/ski_makers/")
   end
 
+  it 'has clickable link to destroy current ski' do
+    Ski.destroy_all
+    SkiMaker.destroy_all
+
+    salomon = SkiMaker.create!(company_name: "Salomon", years_active: 35, makes_snowboards: true)
+    spark = salomon.skis.create!(model: "QST Spark", ski_type: "Park", longest_offered_cm: 189, symmetrical: true)
+    blank = salomon.skis.create!(model: "QST Blank", ski_type: "All Mountain", longest_offered_cm: 202, symmetrical: false)
+
+    visit "/skis/#{blank.id}"
+    click_on 'DELETE'
+
+    expect(current_path).to eq("/skis")
+    save_and_open_page
+
+    expect(page).to_not have_content("Model Name: #{blank.model}")
+    expect(page).to_not have_content("Longest Size Available: #{blank.longest_offered_cm}")
+
+    expect(page).to have_content("Model Name: #{spark.model}")
+    expect(page).to have_content("Longest Size Available: #{spark.longest_offered_cm}")
+  end
+
 end

--- a/spec/features/skis/skis_index_spec.rb
+++ b/spec/features/skis/skis_index_spec.rb
@@ -86,12 +86,12 @@ RSpec.describe 'the /skis index page' do
     faction = SkiMaker.create!(company_name: "Faction", years_active: 13, makes_snowboards: false)
     agent = faction.skis.create!(model: "Agent", ski_type: "Park", longest_offered_cm: 195, symmetrical: true)
     prodigy = faction.skis.create!(model: "Prodigy", ski_type: "Park", longest_offered_cm: 198, symmetrical: true)
-    ct = faction.skis.create!(model: "CT 2.0", ski_type: "Backcountry", longest_offered_cm: 213, symmetrical: false)
+    ct = faction.skis.create!(model: "CT 2.0", ski_type: "Backcountry", longest_offered_cm: 213, symmetrical: true)
 
-    _1000 = SkiMaker.create!(company_name: "1000 Skis", years_active: 2, makes_snowboards: false)
+    _1000 = SkiMaker.create!(company_name: "1000 Skis", years_active: 2, makes_snowboards: true)
     park = _1000.skis.create!(model: "Park", ski_type: "Park/Pipe", longest_offered_cm: 199, symmetrical: true)
-    all_mtn = _1000.skis.create!(model: "All MTN", ski_type: "All Mountain", longest_offered_cm: 201, symmetrical: false)
-    powder = _1000.skis.create!(model: "PWDER", ski_type: "Powder/Backcountry", longest_offered_cm: 211, symmetrical: false)
+    all_mtn = _1000.skis.create!(model: "All MTN", ski_type: "All Mountain", longest_offered_cm: 201, symmetrical: true)
+    powder = _1000.skis.create!(model: "PWDER", ski_type: "Powder/Backcountry", longest_offered_cm: 211, symmetrical: true)
 
     visit "/skis/"
     # save_and_open_page
@@ -112,19 +112,18 @@ RSpec.describe 'the /skis index page' do
     _1000 = SkiMaker.create!(company_name: "1000 Skis", years_active: 2, makes_snowboards: true)
     park = _1000.skis.create!(model: "Park", ski_type: "Park/Pipe", longest_offered_cm: 199, symmetrical: true)
     all_mtn = _1000.skis.create!(model: "All MTN", ski_type: "All Mountain", longest_offered_cm: 201, symmetrical: true)
-    # require "pry"; binding.pry
+  
     visit "/skis"
 
     within "#ski-#{park.model}" do
       click_on "DELETE"
     end
-    save_and_open_page
+
     expect(current_path).to eq("/skis")
     expect(page).to_not have_content("Model Name: Park}")
     expect(page).to have_content("Model Name: #{agent.model}")
     expect(page).to have_content("Model Name: #{ct.model}")
     expect(page).to have_content("Model Name: #{all_mtn.model}")
-
   end
 
 

--- a/spec/features/skis/skis_index_spec.rb
+++ b/spec/features/skis/skis_index_spec.rb
@@ -94,9 +94,9 @@ RSpec.describe 'the /skis index page' do
     powder = _1000.skis.create!(model: "PWDER", ski_type: "Powder/Backcountry", longest_offered_cm: 211, symmetrical: false)
 
     visit "/skis/"
+    # save_and_open_page
 
     click_on "Edit #{agent.model}"
-    # save_and_open_page
     expect(current_path).to eq("/skis/#{agent.id}/edit")
   end
 
@@ -107,22 +107,24 @@ RSpec.describe 'the /skis index page' do
 
     faction = SkiMaker.create!(company_name: "Faction", years_active: 13, makes_snowboards: false)
     agent = faction.skis.create!(model: "Agent", ski_type: "Park", longest_offered_cm: 195, symmetrical: true)
+    ct = faction.skis.create!(model: "CT 2.0", ski_type: "Backcountry", longest_offered_cm: 213, symmetrical: true)
 
-    _1000 = SkiMaker.create!(company_name: "1000 Skis", years_active: 2, makes_snowboards: false)
+    _1000 = SkiMaker.create!(company_name: "1000 Skis", years_active: 2, makes_snowboards: true)
     park = _1000.skis.create!(model: "Park", ski_type: "Park/Pipe", longest_offered_cm: 199, symmetrical: true)
-    powder = _1000.skis.create!(model: "PWDER", ski_type: "Powder/Backcountry", longest_offered_cm: 211, symmetrical: false)
+    all_mtn = _1000.skis.create!(model: "All MTN", ski_type: "All Mountain", longest_offered_cm: 201, symmetrical: true)
+    # require "pry"; binding.pry
+    visit "/skis"
 
-    visit "/skis/"
-
-    within "#ski-#{powder.model}" do
+    within "#ski-#{park.model}" do
       click_on "DELETE"
-
     end
     save_and_open_page
     expect(current_path).to eq("/skis")
-    expect(page).to_not have_content("Model Name: #{powder.model}")
+    expect(page).to_not have_content("Model Name: Park}")
     expect(page).to have_content("Model Name: #{agent.model}")
-    expect(page).to have_content("Model Name: #{park.model}")
+    expect(page).to have_content("Model Name: #{ct.model}")
+    expect(page).to have_content("Model Name: #{all_mtn.model}")
+
   end
 
 

--- a/spec/features/skis/skis_index_spec.rb
+++ b/spec/features/skis/skis_index_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'the /skis index page' do
     shaman = icelantic.skis.create!(model: "Shaman", ski_type: "Powder", longest_offered_cm: 209, symmetrical: false)
 
     visit "/skis/"
-    # save_and_open_page
+
     expect(page).to have_content("Model Name: #{park.model}")
     expect(page).to have_content("Ski Type: #{park.ski_type}")
     expect(page).to have_content("Longest Size Available: #{park.longest_offered_cm}")
@@ -28,30 +28,7 @@ RSpec.describe 'the /skis index page' do
 
     expect(page).to_not have_content("Model Name: #{all_mtn.model}")
     expect(page).to_not have_content("Model Name: #{shaman.model}")
-
-
-
   end
-
-  # xit '/skis displays all skis with their attributes' do
-  #   ski_maker1 = SkiMaker.create(company_name: "Line", years_active: 15, makes_snowboards: false)
-  #   ski_maker2 = SkiMaker.create(company_name: "1000 Skis", years_active: 2, makes_snowboards: false)
-  #
-  #   ski_1 = ski_maker1.skis.create(model: "Chronic", ski_type: "Park", longest_offered_cm: 191, symmetrical: true)
-  #   ski_2 = ski_maker2.skis.create(model: "All MTN", ski_type: "All Mountain", longest_offered_cm: 201, symmetrical: false)
-  #
-  #   visit "/skis/"
-  #   # save_and_open_page
-  #
-  #   expect(page).to have_content(ski_1.model)
-  #   expect(page).to have_content(ski_1.ski_type)
-  #   expect(page).to have_content(ski_1.longest_offered_cm)
-  #   expect(page).to have_content(ski_1.symmetrical)
-  #   expect(page).to have_content(ski_2.model)
-  #   expect(page).to have_content(ski_2.ski_type)
-  #   expect(page).to have_content(ski_2.longest_offered_cm)
-  #   expect(page).to have_content(ski_2.symmetrical)
-  # end
 
   it 'has clickable link to skis#index' do
     icelantic = SkiMaker.create!(company_name: "Icelantic", years_active: 15, makes_snowboards: false)
@@ -112,7 +89,7 @@ RSpec.describe 'the /skis index page' do
     _1000 = SkiMaker.create!(company_name: "1000 Skis", years_active: 2, makes_snowboards: true)
     park = _1000.skis.create!(model: "Park", ski_type: "Park/Pipe", longest_offered_cm: 199, symmetrical: true)
     all_mtn = _1000.skis.create!(model: "All MTN", ski_type: "All Mountain", longest_offered_cm: 201, symmetrical: true)
-  
+
     visit "/skis"
 
     within "#ski-#{park.model}" do

--- a/spec/features/skis/skis_index_spec.rb
+++ b/spec/features/skis/skis_index_spec.rb
@@ -100,4 +100,30 @@ RSpec.describe 'the /skis index page' do
     expect(current_path).to eq("/skis/#{agent.id}/edit")
   end
 
+  it 'has a link to delete ski next to each ski, clicking refreshes page with ski destroyed' do
+
+    Ski.destroy_all
+    SkiMaker.destroy_all
+
+    faction = SkiMaker.create!(company_name: "Faction", years_active: 13, makes_snowboards: false)
+    agent = faction.skis.create!(model: "Agent", ski_type: "Park", longest_offered_cm: 195, symmetrical: true)
+
+    _1000 = SkiMaker.create!(company_name: "1000 Skis", years_active: 2, makes_snowboards: false)
+    park = _1000.skis.create!(model: "Park", ski_type: "Park/Pipe", longest_offered_cm: 199, symmetrical: true)
+    powder = _1000.skis.create!(model: "PWDER", ski_type: "Powder/Backcountry", longest_offered_cm: 211, symmetrical: false)
+
+    visit "/skis/"
+
+    within "#ski-#{powder.model}" do
+      click_on "DELETE"
+
+    end
+    save_and_open_page
+    expect(current_path).to eq("/skis")
+    expect(page).to_not have_content("Model Name: #{powder.model}")
+    expect(page).to have_content("Model Name: #{agent.model}")
+    expect(page).to have_content("Model Name: #{park.model}")
+  end
+
+
 end

--- a/spec/models/ski_maker_spec.rb
+++ b/spec/models/ski_maker_spec.rb
@@ -65,5 +65,15 @@ RSpec.describe SkiMaker, type: :model do
 
       expect(icelantic.over_given_length(200)).to eq([shaman, saba])
     end
+
+    it 'has a method to return the count of a makers skis' do
+      Ski.destroy_all
+      SkiMaker.destroy_all
+      line = SkiMaker.create!(company_name: "Line", years_active: 15, makes_snowboards: false)
+      blade = line.skis.create!(model: "BLADE", ski_type: "Powder", longest_offered_cm: 215, symmetrical: false)
+      tom = line.skis.create!(model: "Tom Wallisch Pro", ski_type: "Park", longest_offered_cm: 205, symmetrical: true)
+      chronic = line.skis.create!(model: "Chronic", ski_type: "Park", longest_offered_cm: 204, symmetrical: true)
+      expect(line.skis_count).to eq(3)
+    end
   end
 end

--- a/spec/models/ski_maker_spec.rb
+++ b/spec/models/ski_maker_spec.rb
@@ -50,7 +50,20 @@ RSpec.describe SkiMaker, type: :model do
       saba = icelantic.skis.create!(model: "Saba", ski_type: "All Mountain", longest_offered_cm: 201, symmetrical: false)
 
       expect(icelantic.sort_alpha).to eq([maiden, nomad, saba, shaman])
+    end
 
+    it 'returns all skis over a given length' do
+      Ski.destroy_all
+      SkiMaker.destroy_all
+
+      icelantic = SkiMaker.create!(company_name: "Icelantic", years_active: 15, makes_snowboards: false)
+
+      nomad = icelantic.skis.create!(model: "Nomad", ski_type: "Park", longest_offered_cm: 191, symmetrical: true)
+      shaman = icelantic.skis.create!(model: "Shaman", ski_type: "Powder", longest_offered_cm: 209, symmetrical: false)
+      maiden = icelantic.skis.create!(model: "Madien", ski_type: "Park", longest_offered_cm: 178, symmetrical: true)
+      saba = icelantic.skis.create!(model: "Saba", ski_type: "All Mountain", longest_offered_cm: 201, symmetrical: false)
+
+      expect(icelantic.over_given_length).to eq([nomad, shaman, saba])
     end
   end
 end

--- a/spec/models/ski_maker_spec.rb
+++ b/spec/models/ski_maker_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe SkiMaker, type: :model do
       maiden = icelantic.skis.create!(model: "Madien", ski_type: "Park", longest_offered_cm: 178, symmetrical: true)
       saba = icelantic.skis.create!(model: "Saba", ski_type: "All Mountain", longest_offered_cm: 201, symmetrical: false)
 
-      expect(icelantic.over_given_length).to eq([nomad, shaman, saba])
+      expect(icelantic.over_given_length(200)).to eq([shaman, saba])
     end
   end
 end

--- a/spec/models/ski_spec.rb
+++ b/spec/models/ski_spec.rb
@@ -62,25 +62,6 @@ RSpec.describe Ski, type: :model do
 
     end
 
-    # it 'sorts the skis by model name alphabetically' do
-    #   Ski.destroy_all
-    #   SkiMaker.destroy_all
-    #
-    #   icelantic = SkiMaker.create!(company_name: "Icelantic", years_active: 15, makes_snowboards: false)
-    #
-    #   nomad = icelantic.skis.create!(model: "Nomad", ski_type: "Park", longest_offered_cm: 191, symmetrical: true)
-    #   shaman = icelantic.skis.create!(model: "Shaman", ski_type: "Powder", longest_offered_cm: 209, symmetrical: false)
-    #   maiden = icelantic.skis.create!(model: "Madien", ski_type: "Park", longest_offered_cm: 178, symmetrical: true)
-    #   saba = icelantic.skis.create!(model: "Saba", ski_type: "All Mountain", longest_offered_cm: 201, symmetrical: false)
-    #
-    #   expect(icelantic.sort_alpha).to eq([maiden, nomad, saba, shaman])
-    #
-    # end
-
-
-
-
-
 
   end
 end


### PR DESCRIPTION
In this PR:
- Finish iteration 3
- add destroy/delete link and functionality for both ski_makers and skis, links to delete can be found on all relevant pages and next to all relevant parents/children on #index and #show pages
- add display skis over x given length table/functionality to a ski_maker_skis#show page.  User will input an integer and after clicking submit will only see skis that have a longest_cm_offered that are above their input
- Some refactoring: adding orderly appear_before expectations in several tests to insure that proper order is present on relevant pages/views.  Also added a skis_count method to the ski_maker model, switched this to be used in the #show action and view for a ski_maker